### PR TITLE
fix(mesh): Use single color for DisplayMesh and DisplayPolyface

### DIFF
--- a/ladybug_display_schema/display2d.py
+++ b/ladybug_display_schema/display2d.py
@@ -1,9 +1,8 @@
 """Schemas for geometric display objects in 2D space."""
-from typing import List, Union
-from pydantic import Field, constr, root_validator
+from typing import Union
+from pydantic import Field, constr
 
-from .base import DisplayBaseModel, SingleColorBase, LineCurveBase, \
-    Color, DisplayModes, Default
+from .base import SingleColorBase, LineCurveBase, DisplayModes, Default
 from .geometry2d import Vector2D, Point2D, Ray2D, LineSegment2D, \
     Polyline2D, Arc2D, Polygon2D, Mesh2D
 
@@ -92,7 +91,7 @@ class DisplayPolygon2D(LineCurveBase):
     )
 
 
-class DisplayMesh2D(DisplayBaseModel):
+class DisplayMesh2D(SingleColorBase):
     """A mesh in 2D space with display properties."""
 
     type: constr(regex='^DisplayMesh2D$') = 'DisplayMesh2D'
@@ -102,30 +101,8 @@ class DisplayMesh2D(DisplayBaseModel):
         description='Mesh2D for the geometry.'
     )
 
-    colors: List[Color] = Field(
-        ...,
-        description='A list of colors that correspond to either the faces '
-        'of the mesh or the vertices of the mesh. It can also be a single color '
-        'for the entire mesh.'
-    )
-
     display_mode: DisplayModes = Field(
         DisplayModes.surface,
         description='Text to indicate the display mode (surface, wireframe, '
         'etc.). The DisplayModes enumeration contains all acceptable types.'
     )
-
-    @root_validator
-    def check_colors_align(cls, values):
-        """Check that there are an acceptable number of colors for the mesh."""
-        colors, geo = values.get('colors'), values.get('geometry')
-        if colors is None:
-            return values
-        if len(colors) in (1, len(geo.faces), len(geo.vertices)):
-            return values
-        else:
-            raise ValueError(
-                'Number of colors ({}) does not match the number of mesh faces '
-                '({}) nor the number of vertices ({}).'.format(
-                    len(colors), len(geo.faces), len(geo.vertices))
-            )

--- a/ladybug_display_schema/display3d.py
+++ b/ladybug_display_schema/display3d.py
@@ -1,9 +1,9 @@
 """Schemas for geometric display objects in 3D space."""
-from typing import List, Union
-from pydantic import Field, constr, root_validator
+from typing import Union
+from pydantic import Field, constr
 
-from .base import DisplayBaseModel, SingleColorBase, LineCurveBase, \
-    Color, DisplayModes, HorizontalAlignments, VerticalAlignments, Default
+from .base import SingleColorBase, LineCurveBase, DisplayModes, \
+    HorizontalAlignments, VerticalAlignments, Default
 from .geometry3d import Vector3D, Point3D, Ray3D, Plane, LineSegment3D, \
     Polyline3D, Arc3D, Face3D, Mesh3D, Polyface3D, Sphere, Cone, Cylinder
 
@@ -121,7 +121,7 @@ class DisplayFace3D(SingleColorBase):
     )
 
 
-class DisplayMesh3D(DisplayBaseModel):
+class DisplayMesh3D(SingleColorBase):
     """A mesh in 3D space with display properties."""
 
     type: constr(regex='^DisplayMesh3D$') = 'DisplayMesh3D'
@@ -131,36 +131,14 @@ class DisplayMesh3D(DisplayBaseModel):
         description='Mesh3D for the geometry.'
     )
 
-    colors: List[Color] = Field(
-        ...,
-        description='A list of colors that correspond to either the faces '
-        'of the mesh or the vertices of the mesh. It can also be a single color '
-        'for the entire mesh.'
-    )
-
     display_mode: DisplayModes = Field(
         DisplayModes.surface,
         description='Text to indicate the display mode (surface, wireframe, '
         'etc.). The DisplayModes enumeration contains all acceptable types.'
     )
 
-    @root_validator
-    def check_colors_align(cls, values):
-        """Check that there are an acceptable number of colors for the mesh."""
-        colors, geo = values.get('colors'), values.get('geometry')
-        if colors is None:
-            return values
-        if len(colors) in (1, len(geo.faces), len(geo.vertices)):
-            return values
-        else:
-            raise ValueError(
-                'Number of colors ({}) does not match the number of mesh faces '
-                '({}) nor the number of vertices ({}).'.format(
-                    len(colors), len(geo.faces), len(geo.vertices))
-            )
 
-
-class DisplayPolyface3D(DisplayBaseModel):
+class DisplayPolyface3D(SingleColorBase):
     """A Polyface in 3D space with display properties."""
 
     type: constr(regex='^DisplayPolyface3D$') = 'DisplayPolyface3D'
@@ -170,33 +148,11 @@ class DisplayPolyface3D(DisplayBaseModel):
         description='Polyface3D for the geometry.'
     )
 
-    colors: List[Color] = Field(
-        ...,
-        description='A list of colors that correspond to either the faces of the '
-        'polyface or the vertices of the polyface. It can also be a single color '
-        'for the entire polyface.'
-    )
-
     display_mode: DisplayModes = Field(
         DisplayModes.surface,
         description='Text to indicate the display mode (surface, wireframe, '
         'etc.). The DisplayModes enumeration contains all acceptable types.'
     )
-
-    @root_validator
-    def check_colors_align(cls, values):
-        """Check that there are an acceptable number of colors for the mesh."""
-        colors, geo = values.get('colors'), values.get('geometry')
-        if colors is None:
-            return values
-        if len(colors) in (1, len(geo.face_indices), len(geo.vertices)):
-            return values
-        else:
-            raise ValueError(
-                'Number of colors ({}) does not match the number of mesh faces '
-                '({}) nor the number of vertices ({}).'.format(
-                    len(colors), len(geo.face_indices), len(geo.vertices))
-            )
 
 
 class DisplaySphere(SingleColorBase):

--- a/samples/display/mesh_2d.json
+++ b/samples/display/mesh_2d.json
@@ -14,14 +14,12 @@
             [2, 3, 4]
         ]
     },
-    "colors": [
-        {
-            "type": "Color",
-            "r": 255,
-            "g": 0,
-            "b": 0,
-            "a": 255
-        }
-    ],
+    "color": {
+        "type": "Color",
+        "r": 255,
+        "g": 0,
+        "b": 0,
+        "a": 255
+    },
     "display_mode": "Surface"
 }

--- a/samples/display/mesh_3d.json
+++ b/samples/display/mesh_3d.json
@@ -14,14 +14,12 @@
             [2, 3, 4]
         ]
     },
-    "colors": [
-        {
-            "type": "Color",
-            "r": 255,
-            "g": 0,
-            "b": 0,
-            "a": 255
-        }
-    ],
+    "color": {
+        "type": "Color",
+        "r": 255,
+        "g": 0,
+        "b": 0,
+        "a": 255
+    },
     "display_mode": "Surface"
 }

--- a/samples/display/polyface_3d.json
+++ b/samples/display/polyface_3d.json
@@ -50,14 +50,12 @@
             "edge_types": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
         }
     },
-    "colors": [
-        {
-            "type": "Color",
-            "r": 255,
-            "g": 0,
-            "b": 0,
-            "a": 255
-        }
-    ],
+    "color": {
+        "type": "Color",
+        "r": 255,
+        "g": 0,
+        "b": 0,
+        "a": 255
+    },
     "display_mode": "Surface"
 }


### PR DESCRIPTION
I realized that we don't really have a strong use case for this and it's better to keep it consistent with the other display objects. If people need things colored by face or vertex, it's pretty much always for an AnalysisGeometry.