### PR TITLE
fix(deps): Loosen pydantic requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pydantic-openapi-helper==0.2.10
+pydantic-openapi-helper>=0.2.10


### PR DESCRIPTION
I'm doing this mostly because ladybug VTK hard-coded a version of pydantic that was different than the pydantic-openapi-helper.